### PR TITLE
feat: Add installation instructions FE part

### DIFF
--- a/airalo-css/instructionsStyle.css
+++ b/airalo-css/instructionsStyle.css
@@ -1,0 +1,193 @@
+#airalo-container {
+  * {
+    font-family: "Inter", sans-serif !important;
+    font-optical-sizing: auto;
+  }
+
+  body {
+    background: var(--gray-50, #f9fafb);
+    margin: 1rem;
+  }
+
+  select {
+    width: 100%;
+
+    padding: var(--25, 0.625rem) var(--5, 1.25rem);
+
+    border-radius: var(--rounded-lg, 0.5rem);
+    border: 1px solid var(--gray-200, #e5e7eb);
+    background: var(--white, #fff);
+  }
+
+  #installation-select {
+    margin: 1rem 0;
+  }
+
+  .container {
+    display: flex;
+    padding: var(--4, 1rem);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--4, 1rem);
+    align-self: stretch;
+
+    border-radius: var(--rounded-lg, 0.5rem);
+    background: var(--white, #fff);
+
+    /* shadow */
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+      0px 1px 2px -1px rgba(0, 0, 0, 0.1);
+  }
+
+  .steps-container {
+    padding: 1rem;
+
+    ol {
+      counter-reset: item;
+      list-style-type: none;
+
+      li {
+        display: flex;
+        align-items: flex-start;
+
+        color: var(--gray-900, #111928);
+
+        /* text-sm/font-normal */
+        font-family: Inter;
+        font-size: 0.875rem;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 150%; /* 1.3125rem */
+
+        margin-bottom: 0.5rem;
+      }
+
+      li:before {
+        content: counter(item) "  ";
+        counter-increment: item;
+        background-color: var(--gray-50, #f9fafb);
+        border-radius: 50%;
+        padding: 0.25rem 0.5rem;
+
+        margin-right: 12px;
+        width: 29px;
+        box-sizing: border-box;
+        text-align: center;
+      }
+    }
+  }
+
+  h1 {
+    color: var(--gray-900, #111928);
+
+    /* text-xl/font-semibold */
+    font-family: Inter;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 150%; /* 1.875rem */
+
+    margin-bottom: 1rem;
+  }
+
+  .step-title {
+    background: var(--gray-50, #f9fafb);
+    display: flex;
+    height: var(--12, 3rem);
+    padding: var(--0, 0rem) var(--4, 1rem);
+    align-items: center;
+    align-self: stretch;
+  }
+
+  h2.step-title {
+    color: var(--gray-500, var(--gray-500, #6b7280));
+
+    /* uppercase/text-xs/font-semibold */
+    font-family: Inter;
+    font-size: 0.75rem;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 150%; /* 1.125rem */
+    text-transform: uppercase;
+  }
+
+  h3 {
+    color: var(--gray-900, var(--gray-900, #111928));
+
+    /* text-sm/font-medium */
+    font-family: Inter;
+    font-size: 0.875rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 150%; /* 1.3125rem */
+  }
+
+  #qr-code-container {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 60%;
+      max-width: 240px;
+      border-radius: 0.5rem;
+      border: 1px solid var(--grey-50, #cfcfd0);
+      background: var(--seashell-100, #fdfdfd);
+
+      padding: 1rem;
+    }
+  }
+
+  #network-container {
+    padding: 1rem;
+    margin-top: 1rem;
+    border-radius: var(--rounded-lg, 0.5rem);
+    background: var(--white, #fff);
+
+    /* shadow */
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+      0px 1px 2px -1px rgba(0, 0, 0, 0.1);
+
+    .network-item-details {
+      margin-bottom: 1rem;
+
+      h3 {
+        margin-bottom: 0.25rem;
+
+        color: var(--gray-500, var(--gray-500, #6b7280));
+
+        font-family: Inter;
+        font-size: 1rem;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 1rem;
+      }
+
+      p {
+        color: var(--gray-900, var(--gray-900, #111928));
+
+        font-family: Inter;
+        font-size: 1rem;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 150%;
+      }
+    }
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  #airalo-container {
+    max-width: 960px;
+    margin: 1rem auto;
+
+    .steps-container {
+      ol {
+        li {
+          align-items: center;
+        }
+      }
+    }
+  }
+}

--- a/airalo-js/instructions.js
+++ b/airalo-js/instructions.js
@@ -1,0 +1,98 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var versionSelect = document.getElementById("version-select");
+  var installationSelect = document.getElementById("installation-select");
+  var stepsDiv = document.getElementById("steps-container");
+  var networkStepsDiv = document.getElementById("network-steps-container");
+  var qrCodeDiv = document.getElementById("qr-code-container");
+  var networkContainer = document.getElementById("network-container");
+
+  function capitalize(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
+  function displaySteps() {
+    var selectedVersion = versionSelect.value.split("-")[0];
+    var selectedMethod = installationSelect.value;
+
+    var steps;
+    var networkSteps;
+    var qrCodeUrl;
+    var apnType;
+    var apnValue;
+    var isRoaming;
+
+    if (selectedVersion === "ios") {
+      steps = Object.values(
+        jsonData.data.instructions.ios[0][selectedMethod].steps
+      );
+      networkSteps = Object.values(
+        jsonData.data.instructions.ios[0].network_setup.steps
+      );
+      qrCodeUrl = jsonData.data.instructions.ios[0][selectedMethod].qr_code_url;
+      apnType = jsonData.data.instructions.ios[0].network_setup.apn_type;
+      apnValue = jsonData.data.instructions.ios[0].network_setup.apn_value;
+      isRoaming = jsonData.data.instructions.ios[0].network_setup.is_roaming;
+    } else if (selectedVersion === "android") {
+      steps = Object.values(
+        jsonData.data.instructions.android[0][selectedMethod].steps
+      );
+      networkSteps = Object.values(
+        jsonData.data.instructions.android[0].network_setup.steps
+      );
+      qrCodeUrl =
+        jsonData.data.instructions.android[0][selectedMethod].qr_code_url;
+      apnType = jsonData.data.instructions.android[0].network_setup.apn_type;
+      apnValue = jsonData.data.instructions.android[0].network_setup.apn_value;
+      isRoaming =
+        jsonData.data.instructions.android[0].network_setup.is_roaming;
+    }
+
+    var ol = document.createElement("ol");
+    for (var i = 0; i < steps.length; i++) {
+      var li = document.createElement("li");
+      li.textContent = steps[i];
+      ol.appendChild(li);
+    }
+
+    stepsDiv.innerHTML = "";
+    stepsDiv.appendChild(ol);
+
+    var olNetwork = document.createElement("ol");
+    for (var i = 0; i < networkSteps.length; i++) {
+      var li = document.createElement("li");
+      li.textContent = networkSteps[i];
+      olNetwork.appendChild(li);
+    }
+    networkStepsDiv.innerHTML = "";
+    networkStepsDiv.appendChild(olNetwork);
+
+    networkContainer.innerHTML = "";
+    var apnInfo = document.createElement("p");
+    apnInfo.innerHTML = `
+      <div class="network-item-details">
+        <h3>Data roaming</h3>
+        <p>${isRoaming ? "On" : "Off"}</p>
+      </div>
+      <div class="network-item-details">
+        <h3>APN</h3>
+        <p>${capitalize(apnType)}</p>
+      </div>
+    `;
+    networkContainer.appendChild(apnInfo);
+
+    if (selectedMethod === "installation_via_qr_code") {
+      var img = document.createElement("img");
+      img.src = qrCodeUrl;
+      img.alt = "QR Code";
+      qrCodeDiv.innerHTML = "";
+      qrCodeDiv.appendChild(img);
+    } else {
+      qrCodeDiv.innerHTML = "";
+    }
+  }
+
+  versionSelect.addEventListener("change", displaySteps);
+  installationSelect.addEventListener("change", displaySteps);
+
+  displaySteps();
+});

--- a/instructions.json
+++ b/instructions.json
@@ -1,0 +1,98 @@
+{
+  "data": {
+    "instructions": {
+      "language": "EN",
+      "ios": [
+        {
+          "model": null,
+          "version": "14,15,13",
+          "installation_via_qr_code": {
+            "steps": {
+              "1": "Go to Settings > Cellular/Mobile > Add Cellular/Mobile Plan.",
+              "2": "Scan the QR Code.",
+              "3": "Tap on 'Add Cellular Plan'.",
+              "4": "Label the eSIM.",
+              "5": "Choose preferred default line to call or send messages.",
+              "6": "Choose the preferred line to use with iMessage, FaceTime, and Apple ID.",
+              "7": "Choose the eSIM plan as your default line for Cellular Data and do not turn on 'Allow Cellular Data Switching' to prevent charges on your other line.",
+              "8": "Your eSIM has been installed successfully, please scroll down to see the settings for accessing data."
+            },
+            "qr_code_data": "LPA:1$lpa.airalo.com$TEST",
+            "qr_code_url": "https://sandbox.airalo.com/qr?expires=1797582688&id=115516&signature=3ee338b2d3405e913f1961993947236cc5c6b6c6c1d22d5e7da6e1281b6cefe6"
+          },
+          "installation_manual": {
+            "steps": {
+              "1": "Go to Settings > Cellular/Mobile > Add Cellular/Mobile Plan.",
+              "2": "Tap on 'Enter Details Manually'.",
+              "3": "Enter your SM-DP+ Address and Activation Code.",
+              "4": "Tap on 'Add Cellular Plan'.",
+              "5": "Label the eSIM.",
+              "6": "Choose preferred default line to call or send messages.",
+              "7": "Choose the preferred line to use with iMessage, FaceTime, and Apple ID.",
+              "8": "Choose the eSIM plan as your default line for Cellular Data and do not turn on 'Allow Cellular Data Switching' to prevent charges on your other line.",
+              "9": "Your eSIM has been installed successfully, please scroll down to see the settings for accessing data."
+            },
+            "smdp_address_and_activation_code": "lpa.airalo.com"
+          },
+          "network_setup": {
+            "steps": {
+              "1": "Select your  eSIM under 'Cellular Plans'.",
+              "2": "Ensure that 'Turn On This Line' is toggled on.",
+              "3": "Go to 'Network Selection' and select the supported network.",
+              "4": "Turn on the Data Roaming.",
+              "5": "Need help? Chat with us."
+            },
+            "apn_type": "manual",
+            "apn_value": "singleall",
+            "is_roaming": true
+          }
+        }
+      ],
+      "android": [
+        {
+          "model": null,
+          "version": null,
+          "installation_via_qr_code": {
+            "steps": {
+              "1": "Go to Settings > Connections > SIM Card Manager.",
+              "2": "Tap on 'Add Mobile Plan'.",
+              "3": "Tap on 'Scan Carrier QR Code' and tap on 'Add'.",
+              "4": "When the plan has been registered, tap 'Ok' to turn on a new mobile plan.",
+              "5": "Your eSIM has been installed successfully, please scroll down to see the settings for accessing data."
+            },
+            "qr_code_data": "LPA:1$lpa.airalo.com$TEST",
+            "qr_code_url": "https://sandbox.airalo.com/qr?expires=1797582688&id=115516&signature=3ee338b2d3405e913f1961993947236cc5c6b6c6c1d22d5e7da6e1281b6cefe6"
+          },
+          "installation_manual": {
+            "steps": {
+              "1": "Go to Settings > Connections > SIM Card Manager.",
+              "2": "Tap on 'Add Mobile Plan'.",
+              "3": "Tap on 'Scan Carrier QR Code' and tap on 'Enter code instead'.",
+              "4": "Enter the Activation Code (SM-DP+ Address & Activation Code).",
+              "5": "When the plan has been registered, tap 'Ok' to turn on a new mobile plan.",
+              "6": "Your eSIM has been installed successfully, please scroll down to see the settings for accessing data."
+            },
+            "smdp_address_and_activation_code": "lpa.airalo.com"
+          },
+          "network_setup": {
+            "steps": {
+              "1": "In the 'SIM Card Manager' select your  eSIM.",
+              "2": "Ensure that your eSIM is turned on under 'Mobile Networks'.",
+              "3": "Enable the Mobile Data.",
+              "4": "Turn on the Data Roaming.",
+              "5": "Go to Settings > Connections > Mobile networks > Network Operators.",
+              "6": "Ensure that the supported network is selected.",
+              "7": "Need help? Chat with us."
+            },
+            "apn_type": "manual",
+            "apn_value": "singleall",
+            "is_roaming": true
+          }
+        }
+      ]
+    }
+  },
+  "meta": {
+    "message": "success"
+  }
+}

--- a/instructions.php
+++ b/instructions.php
@@ -1,0 +1,84 @@
+<html>
+    <head>
+
+        <style><?php require __DIR__ . '/airalo-css/resetStyle.css' ?></style>
+        <style><?php require __DIR__ . '/airalo-css/instructionsStyle.css' ?></style>
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    </head>
+    <body>
+
+        <div id="airalo-container">
+            <?php
+                $path = __DIR__ . '/instructions.json';
+                $raw_data = file_get_contents($path);
+                $json_data = json_decode($raw_data);
+            ?>
+
+            <h1>eSIM Installation</h1>
+
+            <select id="installation-select">
+                <option value='installation_via_qr_code'>Installation via QR Code</option>
+                <option value='installation_manual'>Installation Manual</option>
+            </select>
+
+            <div class="container">
+                
+                <h3>Select device</h3>
+
+                <select id="version-select">
+                <?php
+                    // equivalent in php for this front-end code
+                    // https://github.com/Airalo/airalo-partner-panel-frontend/blob/develop/src/api/transforms/simsTransforms.ts#L72
+                    foreach ($json_data->data->instructions->ios as $ios) {
+                        $version = $ios->version;
+                        if (in_array($version, ['15.0,14.0,13.0,12.0', '15.0,14.0.,13.0,12.0'])) {
+                            $versionName = 'iOS ≤ 15';
+                        } elseif ($version === '16.0') {
+                            $versionName = 'iOS 16';
+                        } else {
+                            $versionName = 'iOS 17';
+                        }
+                        echo "<option value='ios-$version'>$versionName</option>";
+                    }
+
+                    foreach ($json_data->data->instructions->android as $android) {
+                        $version = $android->version;
+                        $model = $android->model;
+                        if ($model === 'Galaxy') {
+                            $versionName = 'Samsung Galaxy';
+                        } elseif ($model === 'Samsung') {
+                            $versionName = 'Samsung';
+                        } else {
+                            $versionName = 'Google Pixel';
+                        }
+                        echo "<option value='android-$version'>$versionName</option>";
+                    }
+                ?>
+                </select>
+
+                <div id="qr-code-container"></div>
+
+                <h2 class="step-title">Step 1: Install eSIM</h2>
+                <div id="steps-container" class="steps-container"></div>
+
+                <h2 class="step-title">Step 2: Access data</h2>
+                <div id="network-steps-container" class="steps-container"></div>
+
+            </div>
+
+            <div id="network-container"></div>
+
+            <script>
+                var jsonData = <?php echo json_encode($json_data); ?>;
+            </script>
+            <script>
+                <?php require __DIR__ . '/airalo-js/instructions.js' ?>
+            </script>
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
**Notes:**
When the SDK will have the installation instructions ready, you can replace the mocked JSON file with the actual response and it should work out of the box. When that happens, you can also delete the `instructions.json` file since it will no longer be needed.

**Mobile view:**

<img src="https://github.com/Airalo/airalo-woocommerce/assets/159771139/359bddb4-4a2e-48ad-b133-202e66fd8c99" 
width="320" />

**Desktop view:**

<img src="https://github.com/Airalo/airalo-woocommerce/assets/159771139/535ded35-a386-4d55-9bf9-a62e56ac5820" width="320" />
